### PR TITLE
Detect vanilla plus server and adjust power amount

### DIFF
--- a/WIIIUI.lua
+++ b/WIIIUI.lua
@@ -3058,6 +3058,11 @@ function GetHealingpowerValue()
 		end
 		
 	end
+
+	-- vanilla plus specific
+	if (serverIsVanillaPlus()) then
+		healPower = healPower + tonumber(math.floor(UnitStat("player",4)*0.33))
+	end
 	
 	-- buffs
 	local _, _, healPowerFromAura = GetPlayerAura("Healing done by magical spells is increased by up to (%d+).")

--- a/WIIIUI.lua
+++ b/WIIIUI.lua
@@ -2959,6 +2959,11 @@ function GetSpellpowerValue()
 			
 		end
 	end
+
+	-- vanilla plus specific
+	if (serverIsVanillaPlus()) then
+		spellPower = spellPower + tonumber(math.floor(UnitStat("player",4)*0.33))
+	end
 	
 	-- buffs
 	local _, _, spellPowerFromAura = GetPlayerAura("Magical damage dealt is increased by up to (%d+).")
@@ -3797,4 +3802,8 @@ function CheckMultiBarAxis()
 	else
 		WIIIUI_menuCheckMultibarRightHorizontal:SetChecked(false)
 	end
+end
+
+function serverIsVanillaPlus()
+	return GetRealmName() == "Hogger"
 end


### PR DESCRIPTION
Hi there,

Here's a pull request, so the addon detects when playing on the vanilla plus server and displays the healing and spell power correctly on Vanilla plus.

(You gain 1/3rd of your int as healing and spell power on the server)